### PR TITLE
Fix child device handler name mismatch

### DIFF
--- a/devicetypes/tonesto7/hampton-bay-fan-controller.src/hampton-bay-fan-controller.groovy
+++ b/devicetypes/tonesto7/hampton-bay-fan-controller.src/hampton-bay-fan-controller.groovy
@@ -262,7 +262,7 @@ def updateChildLabel() {
 def createLightChild() {
 	def childDevice = getChildDevices()?.find { it.device.deviceNetworkId == "${device.deviceNetworkId}-Light" }
 	if (!childDevice) {
-		childDevice = addChildDevice("KOF Zigbee Fan Controller - Light Child Device", "${device.deviceNetworkId}-Light", null,[completedSetup: true, label: "${device.displayName} Light", isComponent: false, componentName: "fanLight", componentLabel: "Light", "data":["parent version":version]])
+		childDevice = addChildDevice("Hampton Bay Fan Controller - Light Child Device", "${device.deviceNetworkId}-Light", null,[completedSetup: true, label: "${device.displayName} Light", isComponent: false, componentName: "fanLight", componentLabel: "Light", "data":["parent version":version]])
 		log.info "Creating child light ${childDevice}"
 	}
 	else {

--- a/devicetypes/tonesto7/hampton-bay-fan-controller.src/hampton-bay-fan-controller.groovy
+++ b/devicetypes/tonesto7/hampton-bay-fan-controller.src/hampton-bay-fan-controller.groovy
@@ -262,7 +262,7 @@ def updateChildLabel() {
 def createLightChild() {
 	def childDevice = getChildDevices()?.find { it.device.deviceNetworkId == "${device.deviceNetworkId}-Light" }
 	if (!childDevice) {
-		childDevice = addChildDevice("Hampton Bay Fan Controller - Light Child Device", "${device.deviceNetworkId}-Light", null,[completedSetup: true, label: "${device.displayName} Light", isComponent: false, componentName: "fanLight", componentLabel: "Light", "data":["parent version":version]])
+		childDevice = addChildDevice("Hampton Bay Fan Controller - Light Device", "${device.deviceNetworkId}-Light", null,[completedSetup: true, label: "${device.displayName} Light", isComponent: false, componentName: "fanLight", componentLabel: "Light", "data":["parent version":version]])
 		log.info "Creating child light ${childDevice}"
 	}
 	else {


### PR DESCRIPTION
Throwing an error when trying to create the light child device: 
`physicalgraph.app.exception.UnknownDeviceTypeException: Device type 'KOF Zigbee Fan Controller - Light Child Device' in namespace 'tonesto7' not found. @line 265 (createLightChild)`
The child device handler was changed from `KOF Zigbee Fan Controller - Light Child Device` to `Hampton Bay Fan Controller - Light Device`.